### PR TITLE
Add option to use external JPEG library

### DIFF
--- a/TextureLoader/CMakeLists.txt
+++ b/TextureLoader/CMakeLists.txt
@@ -51,11 +51,22 @@ PRIVATE
     Diligent-GraphicsEngineInterface 
     Diligent-GraphicsAccessories
     Diligent-GraphicsTools
-    LibJpeg 
     LibPng 
     LibTiff 
     ZLib
 )
+
+if (NOT DILIGENT_EXTERNAL_LIBJPEG)
+    target_link_libraries(Diligent-TextureLoader
+    PRIVATE
+        LibJpeg
+    )
+else()
+    target_link_libraries(Diligent-TextureLoader
+    PRIVATE
+        ${DILIGENT_EXTERNAL_LIBJPEG}
+    )
+endif()
 
 set_target_properties(Diligent-TextureLoader PROPERTIES
     FOLDER DiligentTools


### PR DESCRIPTION
In our project we need to use libjpeg-turbo. We cannot use both libjpeg from Diligent and lijpeg-turbo as it causes duplicate symbols linker errors on Windows.

In this pull request, I'm proposing a way to use another libjpeg library through a `DILIGENT_EXTERNAL_LIBJPEG` option. By default, this should never impact existing projects, but this allows us to use libjpeg-turbo in the whole project and fix the linker errors.

Let me know what you think about this :)

Thanks

 