### PR TITLE
NativeApp: Enable/disable default hotkeys

### DIFF
--- a/NativeApp/include/AppBase.hpp
+++ b/NativeApp/include/AppBase.hpp
@@ -27,8 +27,28 @@
 
 #pragma once
 
+#include "BasicTypes.h"
+#include "FlagEnum.h"
+
 namespace Diligent
 {
+
+/// Flags to handle default hotkeys
+enum HOT_KEY_FLAGS : Uint32
+{
+    /// App doesn't react on default hotkeys
+    HOT_KEY_FLAG_NONE = 0,
+
+    /// App will exit by pressing Escape
+    HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC = 1 << 0,
+
+    /// App will change fullscreen mode on Shift+Enter (only in UWP)
+    HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH = 1 << 1,
+
+    /// Enables all default hotkeys
+    HOT_KEY_FLAG_ALL = ~0u
+};
+DEFINE_FLAG_ENUM_OPERATORS(HOT_KEY_FLAGS)
 
 /// Base class for native applications. Platform-specific classes
 /// such as Win32AppBase, LinuxAppBase are inherited from AppBase.
@@ -69,23 +89,6 @@ public:
         /// Command line was processed with error.
         Error
     };
-
-    /// Flags to handle default hotkeys
-    enum HOT_KEY_FLAGS : Uint32
-    {
-        /// App doesn't react on default hotkeys
-        HOT_KEY_FLAG_NONE = 0,
-
-        /// App will exit by pressing Escape
-        HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC = 1 << 0,
-
-        /// App will change fullscreen mode on Shift+Enter (only in UWP)
-        HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH = 1 << 1,
-
-        /// Enables all default hotkeys
-        HOT_KEY_FLAG_ALL = ~0u
-    };
-    DEFINE_FLAG_ENUM_OPERATORS(HOT_KEY_FLAGS)
 
     virtual ~AppBase() {}
 

--- a/NativeApp/include/AppBase.hpp
+++ b/NativeApp/include/AppBase.hpp
@@ -77,11 +77,15 @@ public:
         HOT_KEY_FLAG_NONE = 0,
 
         /// App will exit by pressing Escape
-        HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC = 1,
+        HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC = 1 << 0,
 
-        /// App wil change fullscreen mode on Shift+Enter (only in UWP)
-        HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH = 1 << 1
+        /// App will change fullscreen mode on Shift+Enter (only in UWP)
+        HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH = 1 << 1,
+
+        /// Enables all default hotkeys
+        HOT_KEY_FLAG_ALL = ~0u
     };
+    DEFINE_FLAG_ENUM_OPERATORS(HOT_KEY_FLAGS)
 
     virtual ~AppBase() {}
 
@@ -173,7 +177,7 @@ public:
     /// Returns default hotkeys handling flags
     virtual HOT_KEY_FLAGS GetHotKeyFlags() const
     {
-        return HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC | HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH;
+        return HOT_KEY_FLAG_ALL;
     }
 };
 

--- a/NativeApp/include/AppBase.hpp
+++ b/NativeApp/include/AppBase.hpp
@@ -70,6 +70,19 @@ public:
         Error
     };
 
+    /// Flags to handle default hotkeys
+    enum HOT_KEY_FLAGS : Uint32
+    {
+        /// App doesn't react on default hotkeys
+        HOT_KEY_FLAG_NONE = 0,
+
+        /// App will exit by pressing Escape
+        HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC = 1,
+
+        /// App wil change fullscreen mode on Shift+Enter (only in UWP)
+        HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH = 1 << 1
+    };
+
     virtual ~AppBase() {}
 
 
@@ -157,10 +170,10 @@ public:
         return false;
     }
 
-    /// Returns true if user can close app by pressing Escape key (and go to Fullscreen mode by Shift+Enter in UWP)
-    virtual bool EnableHotkeys() const
+    /// Returns default hotkeys handling flags
+    virtual HOT_KEY_FLAGS GetHotKeyFlags() const
     {
-        return true;
+        return HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC | HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH;
     }
 };
 

--- a/NativeApp/include/AppBase.hpp
+++ b/NativeApp/include/AppBase.hpp
@@ -156,6 +156,12 @@ public:
     {
         return false;
     }
+
+    /// Returns true if user can close app by pressing Escape key (and go to Fullscreen mode by Shift+Enter in UWP)
+    virtual bool EnableHotkeys() const
+    {
+        return true;
+    }
 };
 
 } // namespace Diligent

--- a/NativeApp/src/Linux/LinuxMain.cpp
+++ b/NativeApp/src/Linux/LinuxMain.cpp
@@ -529,7 +529,7 @@ int x_main(int argc, const char* const* argv)
             }
         }
 
-        if (EscPressed && TheApp->EnableHotkeys())
+        if (EscPressed && TheApp->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC)
             break;
 
         // Render the scene

--- a/NativeApp/src/Linux/LinuxMain.cpp
+++ b/NativeApp/src/Linux/LinuxMain.cpp
@@ -529,7 +529,7 @@ int x_main(int argc, const char* const* argv)
             }
         }
 
-        if (EscPressed)
+        if (EscPressed && TheApp->EnableHotkeys())
             break;
 
         // Render the scene

--- a/NativeApp/src/Linux/LinuxMain.cpp
+++ b/NativeApp/src/Linux/LinuxMain.cpp
@@ -529,7 +529,7 @@ int x_main(int argc, const char* const* argv)
             }
         }
 
-        if (EscPressed && TheApp->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC)
+        if (EscPressed && (TheApp->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC))
             break;
 
         // Render the scene

--- a/NativeApp/src/UWP/App.cpp
+++ b/NativeApp/src/UWP/App.cpp
@@ -296,7 +296,7 @@ void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::Ke
         break;
 
         case VirtualKey::Enter:
-            if(m_bShiftPressed)
+            if(m_bShiftPressed && (m_Main->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH))
             {
                 auto applicationView = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
                 if (applicationView->IsFullScreenMode)
@@ -311,10 +311,7 @@ void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::Ke
         break;
 
         case VirtualKey::Shift:
-            if (m_Main->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH)
-            {
-                m_bShiftPressed = true;
-            }
+            m_bShiftPressed = true;
             break;
     }
 }

--- a/NativeApp/src/UWP/App.cpp
+++ b/NativeApp/src/UWP/App.cpp
@@ -285,14 +285,14 @@ void App::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 
 void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ args)
 {
-    if (!m_Main->EnableHotkeys())
-        return;
-
     auto Key = args->VirtualKey;
     switch(Key)
     {
         case VirtualKey::Escape:
-            CoreApplication::Exit();
+            if (m_Main->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC)
+            {
+                CoreApplication::Exit();
+            }
         break;
 
         case VirtualKey::Enter:
@@ -311,16 +311,16 @@ void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::Ke
         break;
 
         case VirtualKey::Shift:
-            m_bShiftPressed = true;
+            if (m_Main->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_FULL_SCREEN_SWITCH)
+            {
+                m_bShiftPressed = true;
+            }
             break;
     }
 }
 
 void App::OnKeyUp(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ args)
 {
-    if (!m_Main->EnableHotkeys())
-        return;
-
     auto Key = args->VirtualKey;
     switch (Key)
     {

--- a/NativeApp/src/UWP/App.cpp
+++ b/NativeApp/src/UWP/App.cpp
@@ -285,6 +285,9 @@ void App::OnDisplayContentsInvalidated(DisplayInformation^ sender, Object^ args)
 
 void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ args)
 {
+    if (!m_Main->EnableHotkeys())
+        return;
+
     auto Key = args->VirtualKey;
     switch(Key)
     {
@@ -315,6 +318,9 @@ void App::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::Ke
 
 void App::OnKeyUp(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ args)
 {
+    if (!m_Main->EnableHotkeys())
+        return;
+
     auto Key = args->VirtualKey;
     switch (Key)
     {

--- a/NativeApp/src/Win32/WinMain.cpp
+++ b/NativeApp/src/Win32/WinMain.cpp
@@ -196,7 +196,7 @@ LRESULT CALLBACK MessageProc(HWND wnd, UINT message, WPARAM wParam, LPARAM lPara
             return 0;
 
         case WM_CHAR:
-            if (wParam == VK_ESCAPE)
+            if (wParam == VK_ESCAPE && g_pTheApp->EnableHotkeys())
                 PostQuitMessage(0);
             return 0;
 

--- a/NativeApp/src/Win32/WinMain.cpp
+++ b/NativeApp/src/Win32/WinMain.cpp
@@ -196,7 +196,7 @@ LRESULT CALLBACK MessageProc(HWND wnd, UINT message, WPARAM wParam, LPARAM lPara
             return 0;
 
         case WM_CHAR:
-            if (wParam == VK_ESCAPE && g_pTheApp->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC)
+            if (wParam == VK_ESCAPE && (g_pTheApp->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC))
                 PostQuitMessage(0);
             return 0;
 

--- a/NativeApp/src/Win32/WinMain.cpp
+++ b/NativeApp/src/Win32/WinMain.cpp
@@ -196,7 +196,7 @@ LRESULT CALLBACK MessageProc(HWND wnd, UINT message, WPARAM wParam, LPARAM lPara
             return 0;
 
         case WM_CHAR:
-            if (wParam == VK_ESCAPE && g_pTheApp->EnableHotkeys())
+            if (wParam == VK_ESCAPE && g_pTheApp->GetHotKeyFlags() & HOT_KEY_FLAG_ALLOW_EXIT_ON_ESC)
                 PostQuitMessage(0);
             return 0;
 


### PR DESCRIPTION
Create AppBase::EnableHotkeys() method to enable/disable default hotkeys (such as exit from app on Esc and change fullscreen mode on Shift+Enter in UWP).