### PR TITLE
Fixed definition guard for 'IMGUI_DEFINE_MATH_OPERATORS'

### DIFF
--- a/ThirdParty/imGuIZMO.quat/imGuIZMO.h
+++ b/ThirdParty/imGuIZMO.quat/imGuIZMO.h
@@ -17,7 +17,9 @@
 #include <algorithm>
 
 #include "imgui.h"
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
+#endif
 #include "imgui_internal.h"
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Simple fix required if user defines `IMGUI_DEFINE_MATH_OPERATORS` in global cmake scope. Compiler will thow redefinition warnings and treat them as errors