### PR TITLE
Improve precision of float32 to uint8 conversion

### DIFF
--- a/AssetLoader/src/GLTFBuilder.cpp
+++ b/AssetLoader/src/GLTFBuilder.cpp
@@ -27,6 +27,7 @@
 #include "GLTFBuilder.hpp"
 #include "GLTFLoader.hpp"
 #include "GraphicsAccessories.hpp"
+#include <cmath>
 
 namespace Diligent
 {
@@ -71,13 +72,13 @@ inline void ConvertElement(DstType& Dst, const SrcType& Src)
 template <>
 inline void ConvertElement<float, Uint8>(Uint8& Dst, const float& Src)
 {
-    Dst = static_cast<Uint8>(clamp(Src * 255.f, 0.f, 255.f));
+    Dst = static_cast<Uint8>(clamp(std::round(Src * 255.f), 0.f, 255.f));
 }
 
 template <>
 inline void ConvertElement<float, Int8>(Int8& Dst, const float& Src)
 {
-    Dst = static_cast<Int8>(clamp(Src * 127.f, -127.f, 127.f));
+    Dst = static_cast<Int8>(clamp(std::round(Src * 127.f), -127.f, 127.f));
 }
 
 template <typename SrcType, typename DstType>

--- a/AssetLoader/src/GLTFBuilder.cpp
+++ b/AssetLoader/src/GLTFBuilder.cpp
@@ -77,7 +77,7 @@ inline void ConvertElement<float, Uint8>(Uint8& Dst, const float& Src)
 template <>
 inline void ConvertElement<float, Int8>(Int8& Dst, const float& Src)
 {
-    Dst = static_cast<Int8>(clamp(Src * 127.f + 0.5f, -127.f, 127.f));
+    Dst = static_cast<Int8>(clamp(Src * 127.f + sign(Src) * 0.5f, -127.f, 127.f));
 }
 
 template <typename SrcType, typename DstType>

--- a/AssetLoader/src/GLTFBuilder.cpp
+++ b/AssetLoader/src/GLTFBuilder.cpp
@@ -27,7 +27,6 @@
 #include "GLTFBuilder.hpp"
 #include "GLTFLoader.hpp"
 #include "GraphicsAccessories.hpp"
-#include <cmath>
 
 namespace Diligent
 {
@@ -72,13 +71,13 @@ inline void ConvertElement(DstType& Dst, const SrcType& Src)
 template <>
 inline void ConvertElement<float, Uint8>(Uint8& Dst, const float& Src)
 {
-    Dst = static_cast<Uint8>(clamp(std::round(Src * 255.f), 0.f, 255.f));
+    Dst = static_cast<Uint8>(clamp(Src * 255.f + 0.5f, 0.f, 255.f));
 }
 
 template <>
 inline void ConvertElement<float, Int8>(Int8& Dst, const float& Src)
 {
-    Dst = static_cast<Int8>(clamp(std::round(Src * 127.f), -127.f, 127.f));
+    Dst = static_cast<Int8>(clamp(Src * 127.f + 0.5f, -127.f, 127.f));
 }
 
 template <typename SrcType, typename DstType>


### PR DESCRIPTION
# Description
The `float32` to `uint8` conversion tends to truncate the values instead of rounding them before clamping, hence causing a loss of precision in the process. This pull request addresses this issue by rounding the float32 values before clamping them.
