### PR TITLE
RSN Template: fixed 'dict object' has no attribute '{struct name}' issue

### DIFF
--- a/RenderStateNotation/scripts/cxx_template.py
+++ b/RenderStateNotation/scripts/cxx_template.py
@@ -364,7 +364,7 @@ NLOHMANN_JSON_VALIDATE_KEYS(Json, {
 {%- endmacro -%}
 
 {%- for type, info in structs %}
-{{ WriteRSN(type, info['fields'], info['inheritance'], field_size[type], field_size_inv[type]) }}
-{{ ParseRSN(type, info['fields'], info['inheritance'], field_size[type], field_size_inv[type])}}
+{{ WriteRSN(type, info['fields'], info['inheritance'], field_size[type] if type in field_size else {}, field_size_inv[type] if type in field_size_inv else {}) }}
+{{ ParseRSN(type, info['fields'], info['inheritance'], field_size[type] if type in field_size else {}, field_size_inv[type] if type in field_size_inv else {}) }}
 {% endfor %}
 ''')


### PR DESCRIPTION
On Windows I was unable to compile the RenderStateNotation project due to an issue in the cxx_template.py file, this fixes the issue.

I didn't use nullish coalescing because I don't know the minimum version of python that is required so instead I applied a fix that would work in any version of Python 2 and 3.

Here is the output **before** the fix:

```1>------ Rebuild All started: Project: Diligent-RenderStateNotation, Configuration: Debug x64 ------
1>Generating RSN Parser Headers...
1>Generate CXX -> BlendStateParser.hpp
1>Traceback (most recent call last):
1>  File "D:\ProjectName\Dependencies\Repositories\DiligentEngine\DiligentTools\RenderStateNotation\scripts\cxx_generator.py", line 57, in <module>
1>    main()
1>  File "D:\ProjectName\Dependencies\Repositories\DiligentEngine\DiligentTools\RenderStateNotation\scripts\cxx_generator.py", line 50, in main
1>    generate_file(file, os.path.join(args.dir, generated_filename))
1>  File "D:\ProjectName\Dependencies\Repositories\DiligentEngine\DiligentTools\RenderStateNotation\scripts\cxx_parser.py", line 174, in generate_file
1>    cpp.write(CXX_STRUCT_SERIALIZE_TEMPLATE.render(structs=struct_field_map.items(), field_size=field_size_map[0], field_size_inv=field_size_map[1]))
1>  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\jinja2\environment.py", line 1304, in render
1>    self.environment.handle_exception()
1>  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\jinja2\environment.py", line 925, in handle_exception
1>    raise rewrite_traceback_stack(source=source)
1>  File "<template>", line 64, in top-level template code
1>  File "C:\Users\user\AppData\Local\Programs\Python\Python39\lib\site-packages\jinja2\runtime.py", line 828, in _invoke
1>    rv = self._func(*arguments)
1>  File "<template>", line 10, in template
1>jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'RenderTargetBlendDesc'
1>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(249,5): error MSB8066: Custom build for 'D:\ProjectName\Dependencies\Repositories\DiligentEngine\windows-x64\CMakeFiles\0b89bd5f6244e0f73aee9758c34393b1\BlendStateParser.hpp.rule;D:\ProjectName\Dependencies\Repositories\DiligentEngine\DiligentTools\RenderStateNotation\CMakeLists.txt' exited with code 1.
1>Done building project "Diligent-RenderStateNotation.vcxproj" -- FAILED.```