### PR TITLE
Fix header ordering for newer versions of Dear IMGUI

### DIFF
--- a/ThirdParty/imGuIZMO.quat/imGuIZMO.h
+++ b/ThirdParty/imGuIZMO.quat/imGuIZMO.h
@@ -16,10 +16,10 @@
 #pragma once
 #include <algorithm>
 
-#include "imgui.h"
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif
+#include "imgui.h"
 #include "imgui_internal.h"
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As per `imgui_internal.h` (on line 94 on the current version):

```c++
// In 1.89.4, we moved the implementation of "courtesy maths operators" from imgui_internal.h in imgui.h
// As they are frequently requested, we do not want to encourage to many people using imgui_internal.h
#if defined(IMGUI_DEFINE_MATH_OPERATORS) && !defined(IMGUI_DEFINE_MATH_OPERATORS_IMPLEMENTED)
#error Please '#define IMGUI_DEFINE_MATH_OPERATORS' _BEFORE_ including imgui.h!
#endif
```

As such, on versions past the version noted above, compilation will fail. 

This PR simply reorders the header as requested. This is backwards compliant with versions before 1.89.4, as the change was to define the variable before both `imgui.h` and `imgui_internal.h`, instead of just before `imgui_internal.h`.