### PR TITLE
Get GTLFLoader using the normal scale factor

### DIFF
--- a/AssetLoader/interface/GLTFLoader.hpp
+++ b/AssetLoader/interface/GLTFLoader.hpp
@@ -239,6 +239,9 @@ struct Material
 
         // Atlas UV scale and bias are applied after the UV transform.
         float4 AtlasUVScaleAndBias = float4{1, 1, 0, 0};
+
+        float NormalScale = 1.0;
+        float Padding[3] = {};
     };
     static_assert(sizeof(TextureShaderAttribs) % 16 == 0, "TextureShaderAttribs struct must be 16-byte aligned");
 

--- a/AssetLoader/src/GLTFLoader.cpp
+++ b/AssetLoader/src/GLTFLoader.cpp
@@ -1284,8 +1284,15 @@ static void LoadExtensionTexture(const Model& model, const tinygltf::Value& Ext,
         UVSelector = static_cast<float>(TexInfo.Get("texCoord").Get<int>());
     }
 
+    float NormalScale = 1.0;
+    if (TexInfo.Has("scale")) // For normal textures
+    {
+        NormalScale = static_cast<float>(TexInfo.Get("scale").Get<double>());
+    }
+
     Mat.SetTextureId(TexAttribIdx, TexId);
     Mat.GetTextureAttrib(TexAttribIdx).UVSelector = UVSelector;
+    Mat.GetTextureAttrib(TexAttribIdx).NormalScale = NormalScale;
 
     if (TexInfo.Has("extensions"))
     {
@@ -1414,6 +1421,15 @@ void Model::LoadMaterials(const tinygltf::Model& gltf_model, const ModelCreateIn
         ReadKhrTextureTransform(*this, gltf_mat.normalTexture.extensions, MatBuilder, NormalTextureName);
         ReadKhrTextureTransform(*this, gltf_mat.emissiveTexture.extensions, MatBuilder, EmissiveTextureName);
         ReadKhrTextureTransform(*this, gltf_mat.occlusionTexture.extensions, MatBuilder, OcclusionTextureName);
+
+        if (gltf_mat.normalTexture.index >= 0)
+        {
+            const auto TexAttribIdx = GetTextureAttributeIndex(NormalTextureName);
+            if (TexAttribIdx >= 0)
+            {
+                MatBuilder.GetTextureAttrib(TexAttribIdx).NormalScale = static_cast<float>(gltf_mat.normalTexture.scale);
+            }
+        }
 
         // Extensions
 


### PR DESCRIPTION
Paired with https://github.com/DiligentGraphics/DiligentFX/pull/244

Not sure how you keep submodules synced. ~~Still debugging issues with the clear coat normal map. It doesn't match Blender's output at all and I'm not sure why. More interestingly, while the 0.0 scale value disables the image normal, 0.0 scale value does not appear to properly disable the clear coat normal.~~ (FIXED)