### PR TITLE
CMake: Prevent pollution of user system

### DIFF
--- a/RenderStateNotation/CMakeLists.txt
+++ b/RenderStateNotation/CMakeLists.txt
@@ -24,9 +24,7 @@ file(MAKE_DIRECTORY "${RSN_PARSER_GENERATED_HEADERS_DIR}")
 # is not accidentally used.
 file(COPY ../.clang-format DESTINATION "${RSN_PARSER_GENERATED_HEADERS_DIR}")
 
-if (${CMAKE_VERSION} VERSION_EQUAL "3.17.0" OR
-    ${CMAKE_VERSION} VERSION_GREATER "3.17.0")
-    message(STATUS "Trying to use Python3 from virtual env")
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
     set(Python_FIND_VIRTUALENV FIRST)
 endif()
 


### PR DESCRIPTION
This allows the user to run Diligent python steps in a venv, such as conda.

Tested on Ubuntu 25, CMake version 3.31.6.

This feature is only [well-supported in CMake](https://cmake.org/cmake/help/latest/module/FindPython.html) as of version 3.17, so it is gated by a version test.

It might make sense to put this in the root-level CMake, but this is the minimum change to make the Samples repo build cleanly on my system.